### PR TITLE
TEC-11734 Skip deployment on parent module

### DIFF
--- a/DistributedRateLimiters/pom.xml
+++ b/DistributedRateLimiters/pom.xml
@@ -45,6 +45,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.deploy.skip>false</maven.deploy.skip>
+    <phase.prop>deploy</phase.prop>
   </properties>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,8 @@
   <properties>
     <maven.surefire.version>3.0.0-M5</maven.surefire.version>
     <junit.version>5.7.1</junit.version>
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <phase.prop>none</phase.prop>
   </properties>
 
   <!-- Add JUnit to all children -->
@@ -179,6 +181,15 @@
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
+            <executions>
+              <execution>
+                <id>default-deploy</id>
+                <phase>${phase.prop}</phase>
+                <goals>
+                  <goal>deploy</goal>
+                </goals>
+              </execution>
+            </executions>
           </plugin>
           <!-- To generate javadoc -->
           <plugin>


### PR DESCRIPTION
### Description of Changes
Added execution property to Sonatype staging plugin and set parent module to skip `deploy` phase.

### Documentation
Not Applicable.

### Risks & Impacts
None

### Testing
Tested locally, unable to deploy due to missing credentials.