### PR TITLE
SL-3640 Ensure the semaphore never sleeps over max expire time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 1.0.0 (March 24, 2021)
 
 * Initial release
+
+## 1.0.3 (Jan 26, 2023)
+
+* Ensure DistributedSemaphore cannot sleep longer than expiry time

--- a/DistributedRateLimiters/pom.xml
+++ b/DistributedRateLimiters/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.echobox</groupId>
     <artifactId>ebx-distributedratelimiters-sdk-parent</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
   </parent>
 
   <name>ebx-distributedratelimiters-sdk</name>

--- a/DistributedRateLimiters/src/main/java/com/echobox/distributedratelimiters/DistributedSemaphore.java
+++ b/DistributedRateLimiters/src/main/java/com/echobox/distributedratelimiters/DistributedSemaphore.java
@@ -189,7 +189,7 @@ public class DistributedSemaphore extends DistributedRateLimiterBase {
 
   @Override
   protected long getSleepTimeBetweenAcquireAttempts() {
-    //+1 so that we never return 0
-    return (long) (100 * rand.nextDouble()) + 1;
+    // Sleep random time between 1 and max expiry time, so on average sleep half the max expiry time
+    return Math.max((long) (cacheKeyExpireTimeSeconds * rand.nextDouble()), 1);
   }
 }

--- a/DistributedRateLimitersDemo/pom.xml
+++ b/DistributedRateLimitersDemo/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>com.echobox</groupId>
 		<artifactId>ebx-distributedratelimiters-sdk-parent</artifactId>
-		<version>1.0.2</version>
+		<version>1.0.3</version>
 	</parent>
 
         <name>ebx-distributedratelimiters-sdk-demos</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.echobox</groupId>
   <artifactId>ebx-distributedratelimiters-sdk-parent</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <packaging>pom</packaging>
 
   <description>Reference implementations using common rate limiting algorithms extended to work in distributed systems.</description>


### PR DESCRIPTION
### Description of Changes

Ensure that the distibuted semaphore will not sleep for longer than the expiry time, we have a situation where the max expiry is 60s and the semaphore is sleeping for 100.

### Documentation

N/A

### Risks & Impacts

Effects all distributed semaphores when permits are not immediately available

### Testing

Untested

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.